### PR TITLE
Feat/style custom btn

### DIFF
--- a/src/Components/App/App.jsx
+++ b/src/Components/App/App.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
-import './App.css';
-import Bill from '../Bill/Bill';
-import Tip from '../Tip/Tip';
+import { useState, useEffect } from "react";
+import "./App.css";
+import Bill from "../Bill/Bill";
+import Tip from "../Tip/Tip";
 
 function App() {
   const [billData, setBillData] = useState({
@@ -10,12 +10,14 @@ function App() {
     numOfPeople: "",
   });
 
+  const [customTip, setCustomTip] = useState("");
+
   const [amounts, setAmounts] = useState({
     tipAmountPerPerson: 0,
     totalAmountPerPerson: 0,
   });
 
-  const updateBillData = data => {
+  const updateBillData = (data) => {
     setBillData({ ...billData, ...data });
   };
 
@@ -24,7 +26,6 @@ function App() {
   }, [billData]);
 
   const calculateAmounts = () => {
-
     const { bill, tipPercent, numOfPeople } = billData;
 
     const billAmount = parseFloat(bill);
@@ -49,6 +50,10 @@ function App() {
     }
   };
 
+  const resetCustomTip = () => {
+    setCustomTip("");
+  };
+
   return (
     <div className="app">
       <header className="header">
@@ -56,13 +61,19 @@ function App() {
       </header>
       <div className="calculator-wrapper">
         <div className="bill-wrapper">
-          <Bill billData={billData} updateBillData={updateBillData} />
+          <Bill
+            billData={billData}
+            updateBillData={updateBillData}
+            customTip={customTip}
+            setCustomTip={setCustomTip}
+          />
         </div>
         <div className="tip-wrapper">
           <Tip
             setBillData={setBillData}
             tipAmountPerPerson={amounts.tipAmountPerPerson}
             totalAmountPerPerson={amounts.totalAmountPerPerson}
+            resetCustomTip={resetCustomTip}
           />
         </div>
       </div>

--- a/src/Components/Bill/Bill.css
+++ b/src/Components/Bill/Bill.css
@@ -4,8 +4,7 @@
   align-items: center;
 }
 
-.button,
-.custom-tip {
+.button {
   height: 3em;
   width: 7em;
   background-color: #00474a;
@@ -13,7 +12,7 @@
   border: none;
   border-radius: 10px;
   margin: 0.25em;
-  font-family: 'Space Mono', monospace;
+  font-family: "Space Mono", monospace;
   font-weight: bold;
 }
 
@@ -58,6 +57,19 @@
   margin-bottom: 1.2em;
   width: 95%;
   /* border: solid green 1px; */
+}
+
+.custom-tip {
+  background-color: hsl(189, 41%, 97%);
+  height: 3em;
+  width: 7em;
+  color: hsl(184, 14%, 56%);
+  border: none;
+  border-radius: 10px;
+  margin: 0.25em;
+  font-family: "Space Mono", monospace;
+  font-weight: bold;
+  text-align: center;
 }
 
 .num-of-people-wrapper {

--- a/src/Components/Bill/Bill.jsx
+++ b/src/Components/Bill/Bill.jsx
@@ -1,42 +1,41 @@
-import React, { useState } from 'react';
-import './Bill.css';
+import React, { useState } from "react";
+import "./Bill.css";
 
-function Bill({ billData, updateBillData }) {
-  const [customTip, setCustomTip] = useState('');
-  const [clickedButton, setClickedButton] = useState('');
+function Bill({ billData, updateBillData, customTip, setCustomTip }) {
+  const [clickedButton, setClickedButton] = useState("");
 
-  const setValueFromForm = eventOrValue => {
-    if (typeof eventOrValue === 'object') {
+  const setValueFromForm = (eventOrValue) => {
+    if (typeof eventOrValue === "object") {
       const { name, value } = eventOrValue.target;
       updateBillData({ [name]: parseFloat(value) });
 
-      if (name === 'tipPercent') {
-        if (value !== 'Custom') {
+      if (name === "tipPercent") {
+        if (value !== "Custom") {
           setClickedButton(value);
-          setCustomTip('');
+          setCustomTip("");
         } else {
-          setClickedButton('');
+          setClickedButton("");
         }
       }
     } else {
-      if (eventOrValue !== 'Custom') {
+      if (eventOrValue !== "Custom") {
         setClickedButton(eventOrValue);
         updateBillData({ tipPercent: parseFloat(eventOrValue) });
-        setCustomTip('');
+        setCustomTip("");
       } else {
-        setClickedButton('');
+        setClickedButton("");
       }
     }
   };
 
-  const handleCustomTipChange = event => {
+  const handleCustomTipChange = (event) => {
     const value = event.target.value;
     setCustomTip(value);
     updateBillData({ tipPercent: parseFloat(value) });
   };
 
   const resetButtonColors = () => {
-    setClickedButton('');
+    setClickedButton("");
   };
 
   return (
@@ -65,38 +64,38 @@ function Bill({ billData, updateBillData }) {
         <div className="button-wrapper">
           <input
             type="button"
-            className={`button ${clickedButton === '5%' ? 'clicked' : ''}`}
+            className={`button ${clickedButton === "5%" ? "clicked" : ""}`}
             name="tipPercent"
             value="5%"
-            onClick={() => setValueFromForm('5%')}
+            onClick={() => setValueFromForm("5%")}
           />
           <input
             type="button"
-            className={`button ${clickedButton === '10%' ? 'clicked' : ''}`}
+            className={`button ${clickedButton === "10%" ? "clicked" : ""}`}
             name="tipPercent"
             value="10%"
-            onClick={() => setValueFromForm('10%')}
+            onClick={() => setValueFromForm("10%")}
           />
           <input
             type="button"
-            className={`button ${clickedButton === '15%' ? 'clicked' : ''}`}
+            className={`button ${clickedButton === "15%" ? "clicked" : ""}`}
             name="tipPercent"
             value="15%"
-            onClick={() => setValueFromForm('15%')}
+            onClick={() => setValueFromForm("15%")}
           />
           <input
             type="button"
-            className={`button ${clickedButton === '25%' ? 'clicked' : ''}`}
+            className={`button ${clickedButton === "25%" ? "clicked" : ""}`}
             name="tipPercent"
             value="25%"
-            onClick={() => setValueFromForm('25%')}
+            onClick={() => setValueFromForm("25%")}
           />
           <input
             type="button"
-            className={`button ${clickedButton === '50%' ? 'clicked' : ''}`}
+            className={`button ${clickedButton === "50%" ? "clicked" : ""}`}
             name="tipPercent"
             value="50%"
-            onClick={() => setValueFromForm('50%')}
+            onClick={() => setValueFromForm("50%")}
           />
           <input
             type="text"

--- a/src/Components/Tip/Tip.jsx
+++ b/src/Components/Tip/Tip.jsx
@@ -1,16 +1,21 @@
-import React from 'react';
-import './Tip.css';
+import React from "react";
+import "./Tip.css";
 
-function Tip({ setBillData, tipAmountPerPerson, totalAmountPerPerson }) {
-
+function Tip({
+  setBillData,
+  tipAmountPerPerson,
+  totalAmountPerPerson,
+  resetCustomTip,
+}) {
   const resetForm = (event) => {
-    event.preventDefault()
+    event.preventDefault();
     setBillData({
       bill: "",
       tipPercent: "",
-      numOfPeople: ""
-    })
-  }
+      numOfPeople: "",
+    });
+    resetCustomTip("");
+  };
 
   return (
     <>
@@ -20,7 +25,7 @@ function Tip({ setBillData, tipAmountPerPerson, totalAmountPerPerson }) {
         </label>
         <h2 className="dollar-amount">
           {isNaN(tipAmountPerPerson)
-            ? '0.00'
+            ? "0.00"
             : `$${tipAmountPerPerson.toFixed(2)}`}
         </h2>
       </div>
@@ -30,17 +35,15 @@ function Tip({ setBillData, tipAmountPerPerson, totalAmountPerPerson }) {
         </label>
         <h2 className="dollar-amount">
           {isNaN(totalAmountPerPerson)
-            ? '0.00'
+            ? "0.00"
             : `$${totalAmountPerPerson.toFixed(2)}`}
         </h2>
       </div>
-      <div className='reset-button-wrapper'>
-          <button
-          className='reset'
-          onClick={(event) => resetForm(event)}
-          >RESET
-          </button>
-        </div>
+      <div className="reset-button-wrapper">
+        <button className="reset" onClick={(event) => resetForm(event)}>
+          RESET
+        </button>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
### Type of change
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [x]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: Bill.css; App.jsx; Bill.jsx; Tip.jsx
- Short description of changes: 

I started this branch with simplicity in mind.  I wanted to style the 'Custom' tip percent button to match the Frontend Mentor comp.  From there, I went down a quick rabbit hole.  

I wanted the 'Reset' button over on the Tip side, to clear the 'Custom' tip percentage input on the Bill side.  To do this, I lifted the customTip and setCustomTip (useState) up to our App.jsx.  This now allows us to pass it down to both Bill and Tip as needed.

I added the props into the Bill component and Tip component and passed customTip, setCustomTip to both children. The last piece of this is the addition of one function in App.jsx.  

```
  const resetCustomTip = () => {
    setCustomTip("");
  };
```
We pass this function as a prop as well so that the Tip Component has access to it when we want to clear the input. As far as my testing is concerned, I believe everything is working as we had it with the added feature of clearing the 'Custom' tip percentage when you click 'Reset'


