### PR TITLE
Rename setValueFromForm to identifyInputType

### DIFF
--- a/src/Components/Bill/Bill.jsx
+++ b/src/Components/Bill/Bill.jsx
@@ -36,16 +36,14 @@ function Bill({ billData, updateBillData, customTip, setCustomTip }) {
     }
   };
 
-  const setValueFromForm = (eventOrValue) => {
+  const identifyInputType = (eventOrValue) => {
     if (typeof eventOrValue === "object") {
       const { name, value } = eventOrValue.target;
       if (name === "bill" || name === "numOfPeople") {
         handleRegularInputChange(name, value);
       } else if (name === "tipPercent") {
         updateBillData({ [name]: parseFloat(value) }); 
-      } else {
-        updateBillData({ [name]: parseFloat(value) });
-      }
+      } 
     } else {
       handleTipPercentChange(eventOrValue );
     }
@@ -70,7 +68,7 @@ function Bill({ billData, updateBillData, customTip, setCustomTip }) {
             className="input-field"
             placeholder="0"
             value={billData.bill}
-            onChange={setValueFromForm}
+            onChange={identifyInputType}
           />
         </div>
       </div>
@@ -84,35 +82,35 @@ function Bill({ billData, updateBillData, customTip, setCustomTip }) {
             className={`button ${clickedButton === "5%" ? "clicked" : ""}`}
             name="tipPercent"
             value="5%"
-            onClick={() => setValueFromForm("5%")}
+            onClick={() => identifyInputType("5%")}
           />
           <input
             type="button"
             className={`button ${clickedButton === "10%" ? "clicked" : ""}`}
             name="tipPercent"
             value="10%"
-            onClick={() => setValueFromForm("10%")}
+            onClick={() => identifyInputType("10%")}
           />
           <input
             type="button"
             className={`button ${clickedButton === "15%" ? "clicked" : ""}`}
             name="tipPercent"
             value="15%"
-            onClick={() => setValueFromForm("15%")}
+            onClick={() => identifyInputType("15%")}
           />
           <input
             type="button"
             className={`button ${clickedButton === "25%" ? "clicked" : ""}`}
             name="tipPercent"
             value="25%"
-            onClick={() => setValueFromForm("25%")}
+            onClick={() => identifyInputType("25%")}
           />
           <input
             type="button"
             className={`button ${clickedButton === "50%" ? "clicked" : ""}`}
             name="tipPercent"
             value="50%"
-            onClick={() => setValueFromForm("50%")}
+            onClick={() => identifyInputType("50%")}
           />
           <input
             type="text"
@@ -139,7 +137,7 @@ function Bill({ billData, updateBillData, customTip, setCustomTip }) {
               className="input-field num-people"
               placeholder="0"
               value={billData.numOfPeople}
-              onChange={setValueFromForm}
+              onChange={identifyInputType}
               />
         </div>
       </div>


### PR DESCRIPTION
### Type of change
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [x]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [ ]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: Bill.jsx
- Short description of changes: Refactored setValueFromForm to remove unnecessary else statement where `updateBillData({ [name]: parseFloat(value) })` was invoked. Renamed `setValueFromForm` to `identifyInputType`
