### PR TITLE
Add clickedButton state to Tip component

### DIFF
--- a/src/Components/Tip/Tip.jsx
+++ b/src/Components/Tip/Tip.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import "./Tip.css";
 
 function Tip({
@@ -7,6 +7,8 @@ function Tip({
   totalAmountPerPerson,
   resetCustomTip,
 }) {
+  const [clickedButton, setClickedButton] = useState("");
+
   const resetForm = (event) => {
     event.preventDefault();
     setBillData({
@@ -15,13 +17,14 @@ function Tip({
       numOfPeople: "",
     });
     resetCustomTip("");
+    setClickedButton("");
   };
 
   return (
     <>
       <div className="tip-amount-wrapper">
         <label htmlFor="tip-amount" className="amount-label">
-          Tip Amount <br/> <span className="per-person">/ person</span> 
+          Tip Amount <br /> <span className="per-person">/ person</span>
         </label>
         <h2 className="dollar-amount">
           {isNaN(tipAmountPerPerson)
@@ -31,7 +34,7 @@ function Tip({
       </div>
       <div className="total-amount-wrapper">
         <label htmlFor="total-amount" className="amount-label">
-          Total Amount <br/> <span className="per-person">/ person</span> 
+          Total Amount <br /> <span className="per-person">/ person</span>
         </label>
         <h2 className="dollar-amount">
           {isNaN(totalAmountPerPerson)


### PR DESCRIPTION
### Type of change
- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [x]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: Tip.jsx
- Short description of changes: Added `clickedButton` state to the Tip component. We could refactor to lift `clickedButton` state up to App.jsx and then pass it down (props) to both the Bill component and the Tip component. However, ChatGBT thought this solution was completely acceptable as we're allowing each component to control different aspects of the user interaction with state that's contained within each component.  
     - Meaning that in Bill.jsx the `clickedButton` state is re-rendering when the user goes to input something in the `Custom Tip` input. Versus over in the Tip.jsx component the `clickedButton` state is being called in the `resetForm` function.
